### PR TITLE
fix: add offset in search arguments

### DIFF
--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -71,14 +71,18 @@ describe('crud', () => {
         })
 
         const response = await dataProvider.getList('users', {
-          pagination: { page: 0, perPage: 25 },
+          pagination: { page: 1, perPage: 25 },
           sort: { field: 'id', order: 'DESC' },
           filter: { q: 'some search', language: 'en' },
         })
         expect(response.data).toEqual(rows)
         expect(response.total).toEqual(totalCount)
-        expect(search).toHaveBeenCalledWith('some search', 25, {
-          language: 'en',
+        expect(search).toHaveBeenCalledWith('some search', {
+          limit: 25,
+          filter: {
+            language: 'en',
+          },
+          offset: 0,
         })
       })
     })


### PR DESCRIPTION
BREAKING CHANGE: In the search function, other arguments than the query `q` are now passed as an object that includes offset. This allow to use pagination properly while calling this method