### PR TITLE
feat: Remove search custom logic & improve filters to handle search

### DIFF
--- a/src/getList/index.ts
+++ b/src/getList/index.ts
@@ -1,5 +1,5 @@
 import { RequestHandler, Request, Response } from 'express'
-import mapValues from 'lodash/mapValues'
+import { omit } from 'lodash'
 
 import { setGetListHeaders } from './headers'
 
@@ -22,64 +22,59 @@ export type Search<R> = (
 
 export const getMany = <R>(
   doGetFilteredList: GetList<R>,
-  doGetSearchList?: Search<R>,
   filtersOption?: FiltersOption
 ): RequestHandler => async (req, res, next) => {
   try {
-    const { q, limit, offset, filter, order } = parseQuery(
+    const { limit, offset, filter, order } = await parseQuery(
       req.query,
       filtersOption
     )
 
-    if (!q) {
-      const { rows, count } = await doGetFilteredList({
-        filter,
-        limit,
-        offset,
-        order,
-      }, {req, res})
-      setGetListHeaders(res, offset, count, rows.length)
-      res.json(rows)
-    } else {
-      if (!doGetSearchList) {
-        return res.status(400).json({
-          error: 'Search has not been implemented yet for this resource',
-        })
-      }
-      const { rows, count } = await doGetSearchList(q, limit, filter, {req, res})
-      setGetListHeaders(res, offset, count, rows.length)
-      res.json(rows)
-    }
+    const { rows, count } = await doGetFilteredList({
+      filter,
+      limit,
+      offset,
+      order,
+    }, { req, res })
+    setGetListHeaders(res, offset, count, rows.length)
+    res.json(rows)
   } catch (error) {
     next(error)
   }
 }
 
-export const parseQuery = (query: any, filtersOption?: FiltersOption) => {
+export const parseQuery = async (query: any, filtersOption?: FiltersOption) => {
   const { range, sort, filter } = query
 
   const [from, to] = range ? JSON.parse(range) : [0, 100]
 
-  const { q, ...filters } = JSON.parse(filter || '{}')
+  const filters = JSON.parse(filter || '{}')
 
   return {
     offset: from,
     limit: to - from + 1,
-    filter: getFilter(filters, filtersOption),
+    filter: await prepareFilter(filters, filtersOption),
     order: [sort ? JSON.parse(sort) : ['id', 'ASC']] as [[string, string]],
-    q,
   }
 }
 
-const getFilter = (
+const prepareFilter = async (
   filter: Record<string, any>,
-  filtersOption?: FiltersOption
-) =>
-  mapValues(filter, (value, key) => {
-    if (filtersOption && filtersOption[key]) {
-      return filtersOption[key](value)
-    }
-    return value
-  })
+  filterTransform?: FiltersOption
+) => {
+  if (!filterTransform) {
+    return filter
+  }
 
-export type FiltersOption = Record<string, (value: any) => any>
+  const transformedFilter = omit(filter, Object.keys(filterTransform))
+
+  for (const [key, map] of Object.entries(filterTransform)) {
+    if (filter[key] !== undefined) {
+      Object.assign(transformedFilter, await map(filter[key]))
+    }
+  }
+
+  return transformedFilter
+}
+
+export type FiltersOption = Record<string, (value: any) => any | Promise<any>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ export interface Actions<I extends string | number, R> {
   destroy: Destroy | null
   update: Update<R> | null
   getList: GetList<R> | null
-  search: Search<R> | null
 }
 
 interface CrudOptions {
@@ -34,7 +33,6 @@ export const crud = <I extends string | number, R>(
       path,
       getMany(
         actions.getList,
-        actions.search || undefined,
         options && options.filters
       )
     )


### PR DESCRIPTION
BREAKING CHANGE:

search action is not anymore supported. It can be replaced by custom filters:

```diff
app.use(
  crud('/admin/users', {
-    search: async (q, limit) => {
-      const { rows, count } = await User.findAndCountAll({
-        limit,
-        where: {
-          [Op.or]: [
-            { address: { [Op.iLike]: `${q}%` } },
-            { zipCode: { [Op.iLike]: `${q}%` } },
-            { city: { [Op.iLike]: `${q}%` } },
-          ],
-        },
-      })
-
-      return { rows, count }
    },
+   {
+     filters: {
+       q: q => ({
+         [Op.or]: [
+           { address: { [Op.iLike]: `${q}%` } },
+           { zipCode: { [Op.iLike]: `${q}%` } },
+           { city: { [Op.iLike]: `${q}%` } },
+         ],
+       })
+     }
+   }
  })
)
```

Additionally, custom filters returned values are not anymore mapped to the custom filter key to allow more use cases. The mapping must be done within the custom filter logic:

```diff
crud('/admin/users', sequelizeCrud(User), {
  filters: {
    email: value => ({
-     [Op.iLike]: value,
+     {
+        email: {
+          [Op.iLike]: value
+       }
+     }
    }),
  },
})